### PR TITLE
Update

### DIFF
--- a/todocurso.txt
+++ b/todocurso.txt
@@ -44,3 +44,4 @@ Cassiopeia es una constelación ubicada en el hemisferio norte cerca a Andromeda
 
 Daniel Fabián Hernández Gómez dice: Me llamo la atención que unas estrellas son se ven más grandes que otras, y que pareciera que las estrellas grandes están cerca unas de otras. Similarmente, las estrellas pequeñas están cerca unas de las otras.
 
+Lo que me llamó la atención de la constelación de Equuleus fue su mitología. Equuleus fue un hermano o hijo de Pegaso, y fue entregado a Castor por parte de Hermes. Por lo tanto se deberia esperar que la constelación se encontrara cercana a Geminis, pero se encuentra cerca a la de Pegaso. También se puede creer que Equuleus fue el caballo del tridente de Poseidon cuando estaba compitiendo con Atenea por la ciudad de Atenas, lo cual rompe el vinculo con Pegaso.


### PR DESCRIPTION
Lo que me llamó la atención de la constelación de Equuleus fue su mitología. Equuleus fue un hermano o hijo de Pegaso, y fue entregado a Castor por parte de Hermes. Por lo tanto se deberia esperar que la constelación se encontrara cercana a Geminis, pero se encuentra cerca a la de Pegaso. También se puede creer que Equuleus fue el caballo del tridente de Poseidon cuando estaba compitiendo con Atenea por la ciudad de Atenas, lo cual rompe el vinculo con Pegaso.