### PR TITLE
Update todocurso.txt

### DIFF
--- a/todocurso.txt
+++ b/todocurso.txt
@@ -54,4 +54,6 @@ Respecto a la constelación Corona Australis, es interesante como a pesar de que
 
 Celtus: Tienen una posición aproximada de RA 1.5h,dec -10°con una extención de unos 1,231 grados cuadrados. En la mitologia griega Cetus fue creado como un mostruo del mar por poseidon como castigo a Cassiopeia por proclamar que era más hermosa que sus hermanas.
 
+Maria Delgado: Es una constelación que hay una ausencia total de estrellas brillantes El área del cielo que ocupa Cáncer se extiende buena parte de la línea que une a la luminosísima Geminorum con Regulus o Leonis.Es una constelación que hay una ausencia total de estrellas brillantes El área del cielo que ocupa Cáncer se extiende buena parte de la línea que une a la luminosísima Geminorum con Regulus o Leonis.
+
 


### PR DESCRIPTION
Maria Delgado: Es una constelación que hay una ausencia total de estrellas brillantes El área del cielo que ocupa Cáncer se extiende buena parte de la línea que une a la luminosísima Geminorum con Regulus o Leonis.Es una constelación que hay una ausencia total de estrellas brillantes El área del cielo que ocupa Cáncer se extiende buena parte de la línea que une a la luminosísima Geminorum con Regulus o Leonis.